### PR TITLE
Glossary fixes

### DIFF
--- a/src/datas/glossary/data.js
+++ b/src/datas/glossary/data.js
@@ -148,7 +148,7 @@ export const glossaries = [
             },{
                 url: 'trusted-bridge',
                 title: 'Trusted bridge',
-                text: 'A bridge between two blockchains that doesn’t require an intermediary, a committee, or an honest majority assumption to ensure that funds can’t be stolen.',
+                text: 'A bridge between two blockchains that requires either a trusted intermediary, committee, or an honest majority assumption to ensure that funds can’t be stolen.',
             }
         ]
     },{

--- a/src/datas/glossary/data.js
+++ b/src/datas/glossary/data.js
@@ -48,7 +48,7 @@ export const glossaries = [
             {
                 url: 'full-node',
                 title: 'Full node',
-                text: 'A type of node that fully validates a blockchain by downloading each block and executing transactions to verify its validity.',
+                text: 'A type of node that fully verifies a blockchain.',
             }
         ]
     },{

--- a/src/pages/glossary/full-node.js
+++ b/src/pages/glossary/full-node.js
@@ -12,7 +12,7 @@ class GlossaryContent extends React.Component {
     render() {
         return (
             <div className={'glossary-content'}>
-                <p>A type of node that fully validates a blockchain by downloading each block and executing transactions to verify its validity.
+                <p>A type of node that fully verifies a blockchain. To fully verify a block, at minimum, a full node must download the block’s data and check that it has consensus. If full nodes are required to ensure that the transactions are valid, they must also re-execute them.
                 </p>
 
             </div>


### PR DESCRIPTION
- Change definition of full node to include full nodes of blockchains that don't execute transactions.
- Change summary of "trusted bridge" (it was a duplicate of the summary for "trust-minimized bridge").