### PR TITLE
Updates

### DIFF
--- a/src/datas/careers/content.js
+++ b/src/datas/careers/content.js
@@ -10,7 +10,7 @@ export const content = {
     text: 'Join our team of leading engineers, researchers and entrepreneurs in pioneering the first modular blockchain design.',
     button: {
         text: 'Current openings',
-        url: 'https://angel.co/company/celestialabs/jobs'
+        url: 'https://jobs.lever.co/celestia'
     },
     perks:{
         title: 'Perks',

--- a/src/datas/home/hero-section.js
+++ b/src/datas/home/hero-section.js
@@ -9,7 +9,7 @@ export const heroData = {
                 url: '#roadmap'
             },
             {
-                text: 'Experiment with Testnet',
+                text: 'Build on Testnet',
                 class: 'white',
                 type: 'external',
                 url: 'https://docs.celestia.org/nodes/mamaki-testnet'


### PR DESCRIPTION
- change hero CTA from "experiment with testnet" to "build on testnet"
- change "current openings" link on the careers page to the new website with our updated open positions