### PR TITLE
Fix mention of incentivized testnet on homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -90,7 +90,7 @@ class IndexPage extends React.Component {
                               <div className={'row'}>
                                   <div className={'col col-12 col-lg-6'}>
                                       <h3 className={'with-decor'}>Run a node on testnet</h3>
-                                      <div className={'text'}>Test out the Celestia network and earn rewards in our incentivized testnet.</div>
+                                      <div className={'text'}>Experiment and practice running a node on testnet in preparation for mainnet.</div>
                                       <a href="https://docs.celestia.org/nodes/overview" target={'_blank'}>
                                           <button className={'button button-simple'} id={'operator'} role={'button'} tabIndex={0}>Read the Docs</button>
                                       </a>


### PR DESCRIPTION
- First photo (current), second photo (update)

![ewrffd](https://user-images.githubusercontent.com/75361908/194842322-06b1f8b4-360c-4ddc-a800-329928bb19e1.JPG)

![g4rvfsd](https://user-images.githubusercontent.com/75361908/194842345-525072c9-be51-48f2-b229-36fe739020d9.JPG)


Gatsby [link](https://celestiaorgfooterfix.gatsbyjs.io/)