### PR TITLE
Fix roadmap navigation

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -340,7 +340,7 @@ h6{
 }
 
 main{
-  overflow:hidden;
+  overflow-x:hidden;
   width:100%;
   padding-top:40px;
 

--- a/src/scss/sections/cards-section.scss
+++ b/src/scss/sections/cards-section.scss
@@ -12,9 +12,6 @@
 
   .row{
     .col{
-      margin-bottom: -99999px;
-      padding-bottom: 99999px;
-
       @include media-breakpoint-down(lg) {
         margin-bottom:unset;
         padding-bottom:25px;


### PR DESCRIPTION
Fixes #155

Context:
Currently, when user clicks the "See the roadmap" button on index page, it's scrolled to the Roadmap section and previous sections are no longer accessible, even after refreshing the page. This caused by `overflow: hidden` on the `main` container. Another side issue is with padding and and negative margins on cards columns, which causes a huge white gap, described in the issue.