### PR TITLE
Line-height too small, words were overlapping

### DIFF
--- a/src/scss/pages/page-glossary.scss
+++ b/src/scss/pages/page-glossary.scss
@@ -407,7 +407,7 @@
     font-size: 15px;
     color: #000000;
     letter-spacing: 0;
-    line-height: 2px;
+    line-height: 20px;
 
     &.border-right{
       border-right: 1px solid #E4E4E4;


### PR DESCRIPTION
## Overview

Line-height was too small and it caused that words were overlapping. You can see the difference on these two images.

Before:
<img width="1150" alt="Screenshot 2023-02-28 at 9 07 19 AM" src="https://user-images.githubusercontent.com/66002635/221910573-0db131cd-789e-4b10-b0ef-8b85833fa715.png">

After:
<img width="985" alt="Screenshot 2023-02-28 at 9 06 58 AM" src="https://user-images.githubusercontent.com/66002635/221910601-dc10a185-af4b-4f0d-a158-4b1a38b2b6f9.png">

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
