### PR TITLE
Fix issue with 'learn' menu size on Firefox browser

### DIFF
--- a/src/scss/modules/header.scss
+++ b/src/scss/modules/header.scss
@@ -348,7 +348,7 @@ header{
 
         &:hover, &:focus{
           .submenu{
-            max-height:500px;
+            max-height:600px;
             top:60px;
             padding:15px 25px;
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Fixes #198 

[Gatsby link](https://celestiaorgfixmenu83911.gatsbyjs.io/)
<img width="321" alt="Screenshot 2023-04-27 171934" src="https://user-images.githubusercontent.com/75361908/234908884-a999d402-5e1a-448b-aabf-a3117f25a2f4.png">
<img width="317" alt="Screenshot 2023-04-27 171950" src="https://user-images.githubusercontent.com/75361908/234908900-15d1097d-429e-44ce-9b05-ac6e1c5724dc.png">


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
