### PR TITLE
fix: missing redirect, use new URL

### DIFF
--- a/src/datas/what-is-tia/hero-data.js
+++ b/src/datas/what-is-tia/hero-data.js
@@ -6,7 +6,7 @@ export const heroData = {
 			text: "Pay for Data",
 			class: "simple",
 			type: "external",
-			url: "https://docs.celestia.org/learn/submit-data",
+			url: "https://docs.celestia.org/developers/submit-data",
 		},
 		{
 			text: "Stake TIA",


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The new docs site does not have the old redirects set up. Fortunately, in the long run this will help the correct links be used in places like this. This PR updates to the new path, rather than the old URL which redirected on docusaurus to `developers/submit-data`.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
