### PR TITLE
fix don't render blocks when no related data provided

### DIFF
--- a/src/components/ecosystem.js
+++ b/src/components/ecosystem.js
@@ -9,9 +9,9 @@ export default class Ecosystem extends React.Component {
 					<div className={"logo-container"}>
 						<Image alt={this.props.ecosystem.title} filename={this.props.ecosystem.image} />
 					</div>
-					<div className={"category"}>{this.props.category.name}</div>
-					<div className={"title"}>{this.props.ecosystem.title}</div>
-					<div className={"text"}>{this.props.ecosystem.text}</div>
+					{this.props.category.name && <div className={"category"}>{this.props.category.name}</div>}
+					{this.props.ecosystem.title && <div className={"title"}>{this.props.ecosystem.title}</div>}
+					{this.props.ecosystem.text && <div className={"text"}>{this.props.ecosystem.text}</div>}
 				</div>
 			</a>
 		);


### PR DESCRIPTION
This pull request addresses an issue where the Ecosystem component was rendering empty blocks when no related data was provided. The fix introduces conditional rendering for the category, title, and text fields of the Ecosystem component. Now, these fields will only render if their respective data is available, preventing the creation of unnecessary empty DOM elements.