### PR TITLE
fix: trailing slash breaking manual input of copied discord link

### DIFF
--- a/src/datas/community/social-channels.js
+++ b/src/datas/community/social-channels.js
@@ -16,7 +16,7 @@ export const socialChannels = {
 			text: "A hub for developers, node operators, and enthusiasts.",
 			image: "community/discord.png",
 			type: "external",
-			url: "https://discord.com/invite/YsnTPcSfWQ/",
+			url: "https://discord.com/invite/YsnTPcSfWQ",
 		},
         {
 			id: 3,

--- a/src/datas/developer-portal/community.js
+++ b/src/datas/developer-portal/community.js
@@ -10,7 +10,7 @@ export const community = {
 			type: "external",
 			link: {
 				text:"Join Discord",
-				url: "https://discord.com/invite/YsnTPcSfWQ/",
+				url: "https://discord.com/invite/YsnTPcSfWQ",
 			},
 		},
 		{

--- a/src/datas/home/purple-section.js
+++ b/src/datas/home/purple-section.js
@@ -19,7 +19,7 @@ export const purpleData = {
                 icon: 'home/purple-box-3.svg',
                 button:{
                     title:'Ask a question',
-                    url: 'https://discord.com/invite/YsnTPcSfWQ/'
+                    url: 'https://discord.com/invite/YsnTPcSfWQ'
                 }
             },
             {

--- a/src/datas/home/social-channels.js
+++ b/src/datas/home/social-channels.js
@@ -16,7 +16,7 @@ export const socialChannels = {
 			text: "Get involved",
 			image: "home/discord-black.png",
 			type: "external",
-			url: "https://discord.com/invite/YsnTPcSfWQ/",
+			url: "https://discord.com/invite/YsnTPcSfWQ",
 		},
 		{
 			id: 3,


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Users report they couldn't join Discord from the website after copying the join link.

![image](https://github.com/celestiaorg/celestia.org/assets/46639943/23d0e579-aedd-4833-b093-342a01421dcc)

It works without the trailing slash.

For review, as this goes against trailing slash standards, by @musalbas and @alex-beckett 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
