### PR TITLE
Typographical Corrections in Markdown Pages

### DIFF
--- a/src/pages/markdown-pages/learn/sovereign rollups-misconceptions of sovereign rollups.md
+++ b/src/pages/markdown-pages/learn/sovereign rollups-misconceptions of sovereign rollups.md
@@ -16,7 +16,7 @@ description: "Answers to common misconceptions about sovereign rollups."
   <meta name="twitter:site" content="@CelestiaOrg">
   <meta name="twitter:creator" content="@likebeckett">
   <meta name="twitter:title" content="Misconceptions of sovereign rollups">
-  <meta name="twitter:description" content="Answers to common misonceptions about sovereign rollups."> 
+  <meta name="twitter:description" content="Answers to common misconceptions about sovereign rollups."> 
   <meta name="twitter:image" content="https://raw.githubusercontent.com/celestiaorg/celestia.org/main/src/pages/markdown-pages/learn/images/sovereign-rollups-twitter-card.png">
 </head>
 

--- a/src/pages/markdown-pages/resources/contribute.md
+++ b/src/pages/markdown-pages/resources/contribute.md
@@ -38,7 +38,7 @@ The Celestia community is made up of many individuals with a wide range of skill
 ##### Participate in community calls
 <p>
     <ul style="line-height:140%">
-        <li>Watch or particpate in the community <a href="https://github.com/celestiaorg/community-calls" style="color:#7B2BF9;">calls</a></li>
+        <li>Watch or participate in the community <a href="https://github.com/celestiaorg/community-calls" style="color:#7B2BF9;">calls</a></li>
     </ul>
 </p>
 


### PR DESCRIPTION
## Overview
This pull request addresses minor typographical errors found in two markdown files. These corrections enhance the readability and professionalism of the content.

### Commits Included:
1. **Commit acef83db**: Fixes a typo in the Twitter description of the "Misconceptions of sovereign rollups" page.
2. **Commit b488cafb**: Corrects a typographical error in the "Contribute" page, specifically in the community calls section.

