### PR TITLE
adding gatsby-plugin-client-side-redirect to freddirect issue on main…

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,6 +14,7 @@ module.exports = {
 		"gatsby-plugin-gatsby-cloud",
 		"gatsby-plugin-image",
 		"gatsby-plugin-sass",
+		"gatsby-plugin-client-side-redirect",
 		{
 			resolve: "gatsby-plugin-manifest",
 			options: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,5 +4,6 @@ exports.createPages = async ({ graphql, actions }) => {
 	createRedirect({
 		fromPath: `/deploy`,
 		toPath: `/build#deploy`,
+		isPermanent: true,
 	});
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"canvas": "^2.11.2",
 		"gatsby": "^5.12.11",
 		"gatsby-plugin-anchor-links": "^1.2.1",
+		"gatsby-plugin-client-side-redirect": "^1.1.0",
 		"gatsby-plugin-gatsby-cloud": "5.12.2",
 		"gatsby-plugin-google-analytics": "5.12.0",
 		"gatsby-plugin-image": "^3.12.3",


### PR DESCRIPTION
This PR attempting to addresses a redirection issue on the main branch by adding the gatsby-plugin-client-side-redirect to our Gatsby configuration.
Changes

1. gatsby-config.js: Added gatsby-plugin-client-side-redirect to the plugins array. This plugin helps to handle client-side redirection in Gatsby applications.

2. gatsby-node.js: Added isPermanent: true to the createRedirect function. This ensures that the redirect from /deploy to /build#deploy is permanent.

3. package.json: Included gatsby-plugin-client-side-redirect in the project dependencies. This ensures that the plugin is installed when running npm install.

These changes should resolve the redirection issue we were experiencing on the main branch.