### PR TITLE
fix: correct the capitalization for GitHub in the footer

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -23,7 +23,7 @@ const navigation = {
 				type: "external",
 			},
 			{
-				text: "Github",
+				text: "GitHub",
 				url: "https://github.com/celestiaorg",
 				type: "external",
 			},


### PR DESCRIPTION
This commit corrects the capitalization for GitHub in the footer. 