### PR TITLE
fix-build-erros

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,15 @@ jobs:
               with:
                   node-version: "18.17.0"
 
+            # Add this step to install system dependencies
+            - name: Install system dependencies
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev build-essential g++
+
             # Install all the Node dependencies for Gatsby, using your package.json file.
             - name: Install Dependencies
-              run: npm install --legacy-peer-deps
+              run: npm install --legacy-peer-deps --canvas-prebuild-download-mirror=https://github.com/Automattic/node-canvas/releases/download/
 
             # Speaks for itself no?
             - name: Build Gatsby Site

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"@popperjs/core": "^2.9.3",
 		"axios": "^1.6.2",
 		"bootstrap": "^5.1.0",
-		"canvas": "^2.11.2",
+		"canvas": "2.11.2",
 		"gatsby": "^5.12.11",
 		"gatsby-plugin-anchor-links": "^1.2.1",
 		"gatsby-plugin-client-side-redirect": "^1.1.0",


### PR DESCRIPTION
The error you're encountering is related to the canvas package, which is failing to install due to missing dependencies on the GitHub Actions runner. To resolve this issue, we need to install the necessary system dependencies before running npm install. Here's how we can modify the workflow to address this:
1. First, let's update the .github/workflows/main.yml file to install the required system dependencies:
Next, let's update the package.json file to use a specific version of the canvas package that is known to work with Node.js 18.17.0:
These changes should resolve the installation issues:
2. We're installing the necessary system dependencies (libcairo2-dev, libjpeg-dev, libpango1.0-dev, libgif-dev, and build tools) before running npm install.
We've updated the npm install command to use a mirror for downloading pre-built binaries, which can help avoid issues with GitHub's rate limiting.
We've specified a version of canvas that is compatible with Node.js 18.17.0.
This should resolve the build error in the GitHub Actions workflow.
