### PR TITLE
Typo Update sovereign rollups-misconceptions of sovereign rollups.md

### DIFF
--- a/src/pages/markdown-pages/learn/sovereign rollups-misconceptions of sovereign rollups.md
+++ b/src/pages/markdown-pages/learn/sovereign rollups-misconceptions of sovereign rollups.md
@@ -16,7 +16,7 @@ description: "Answers to common misconceptions about sovereign rollups."
   <meta name="twitter:site" content="@CelestiaOrg">
   <meta name="twitter:creator" content="@likebeckett">
   <meta name="twitter:title" content="Misconceptions of sovereign rollups">
-  <meta name="twitter:description" content="Answers to common misonceptions about sovereign rollups."> 
+  <meta name="twitter:description" content="Answers to common misconceptions about sovereign rollups."> 
   <meta name="twitter:image" content="https://raw.githubusercontent.com/celestiaorg/celestia.org/main/src/pages/markdown-pages/learn/images/sovereign-rollups-twitter-card.png">
 </head>
 


### PR DESCRIPTION
### Description
This PR fixes a typo in the `twitter:description` meta tag in the file `sovereign-rollups-misconceptions.md`. 

**Problem:**
The word "misconceptions" was incorrectly spelled as "misonceptions" in the meta tag description:

```html
<meta name="twitter:description" content="Answers to common misonceptions about sovereign rollups.">
```

**Solution:**
The correct spelling is "misconceptions". The fixed line now reads:

```html
<meta name="twitter:description" content="Answers to common misconceptions about sovereign rollups.">
```

**Importance:**
Correct spelling in meta tags is important for search engine optimization (SEO) and user experience. A misspelled word can affect the visibility of the page on search engines and may lead to a poor first impression for users encountering the page. 

Thank you for reviewing this change!