### PR TITLE
Fix duplicate id values in FooterBoxes arrays Update content.js

### DIFF
--- a/src/datas/glossary/content.js
+++ b/src/datas/glossary/content.js
@@ -5,7 +5,7 @@ export const FooterBoxes = [
 		button: {
 			text: "Learn modular",
 			href: "/learn/",
-			id: "career",
+			id: "learn-modular",
 			type: "simple",
 		},
 	},
@@ -15,7 +15,7 @@ export const FooterBoxes = [
 		button: {
 			text: "Get started",
 			href: "https://docs.celestia.org/",
-			id: "operator",
+			id: "build-testnet",
 			type: "simple",
 		},
 	},
@@ -28,7 +28,7 @@ export const FooterBoxes2 = [
 		button: {
 			text: "Get started",
 			href: "https://docs.celestia.org/",
-			id: "operator",
+			id: "experiment-testnet",
 			type: "simple",
 		},
 	},
@@ -38,7 +38,7 @@ export const FooterBoxes2 = [
 		button: {
 			text: "Current openings",
 			href: "/careers/",
-			id: "career",
+			id: "join-team",
 			type: "simple",
 		},
 	},


### PR DESCRIPTION
## Description  
During data structure analysis, duplicate `id` values were found for different objects.  

## Issues:  
1. In the `FooterBoxes` array, the first object had `id: "career"`, while the second had `id: "operator"`.  
2. In the `FooterBoxes2` array, the object with the title `"Experiment with testnet"` also used `id: "operator"`, and the object with the title `"Join our growing team"` used `id: "career"`.  

## Solution:  
- Updated all `id` values to ensure uniqueness across the mentioned arrays.  
- These changes eliminate potential conflicts where unique `id` values are expected.  

